### PR TITLE
Add `updated` to the JSON-LD context

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -133,6 +133,10 @@
       "@id": "didv:serviceEndpoint",
       "@type": "@id"
     },
+    "updated": {
+      "@id": "dc:modified",
+      "@type": "xsd:dateTime"
+    },
     "verificationMethod": {
       "@id": "sec:verificationMethod",
       "@type": "@id"

--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@ consultation with the entry maintainer.
 
     <section>
       <h2><dfn data-lt="created" data-dfn-type="dfn" id="created">created</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#created">Created.</a>
+      <a href="https://www.w3.org/TR/did-core/#created">The term `created` is defined in the DID Core Specification</a>.
 
       <pre class="example">
 {
@@ -475,7 +475,7 @@ consultation with the entry maintainer.
 
     <section>
       <h2><dfn data-lt="updated" data-dfn-type="dfn" id="updated">updated</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#updated">Updated.</a>
+      <a href="https://www.w3.org/TR/did-core/#updated">The term `updated` is defined in the DID Core Specification</a>.
 
       <pre class="example">
 {

--- a/index.html
+++ b/index.html
@@ -439,6 +439,76 @@ consultation with the entry maintainer.
     </section>
 
     <section>
+      <h2><dfn data-lt="created" data-dfn-type="dfn" id="created">created</dfn></h2>
+      <a href="https://www.w3.org/TR/did-core/#created">Created.</a>
+
+      <pre class="example">
+{
+  "created": "2002-10-10T17:00:00Z"
+}
+      </pre>
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="updated" data-dfn-type="dfn" id="updated">updated</dfn></h2>
+      <a href="https://www.w3.org/TR/did-core/#updated">Updated.</a>
+
+      <pre class="example">
+{
+  "updated": "2016-10-17T02:41:00Z"
+}
+      </pre>
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
       <h2><dfn data-lt="keyAgreement" data-dfn-type="dfn" id="keyAgreement">keyAgreement</dfn></h2>
       <p class="issue">
         Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>

--- a/schemas/didDocument/didDocument.json
+++ b/schemas/didDocument/didDocument.json
@@ -108,6 +108,18 @@
         } 
       }]
       }
+    },
+    "created": {
+      "title": "Created",
+      "description": "https://w3c.github.io/did-core-registries/#created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated": {
+      "title": "Updated",
+      "description": "https://w3c.github.io/did-core-registries/#updated",
+      "type": "string",
+      "format": "date-time"
     }
   },
   "required": ["id"],


### PR DESCRIPTION
`created` was present, but `updated` was not, assume it was an oversight.

They're both missing from the JSON Schema though, and the html of the registries - does that need fixing too?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core-registries/pull/35.html" title="Last updated on May 9, 2020, 10:31 AM UTC (ba85a16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core-registries/35/46b7cb4...ba85a16.html" title="Last updated on May 9, 2020, 10:31 AM UTC (ba85a16)">Diff</a>