### PR TITLE
Restructure to use tables for spec links

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,9 +225,37 @@ consultation with the entry maintainer.
     </p>
 
     <section>
-      <h2><dfn data-lt="@context" data-dfn-type="dfn" id="@context">@context</dfn></h2>
-      <p>Required for JSON-LD. Optional for representations other than JSON-LD.</p>
-      <pre class="example">
+      <h3><dfn data-lt="@context" data-dfn-type="dfn" id="@context">@context</dfn></h3>
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#production-0">DID Core</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of @context property">
         {
           "@context": [
             "https://www.w3.org/ns/did/v1",
@@ -237,10 +265,15 @@ consultation with the entry maintainer.
         }
       </pre>
 
+    </section>
+    <section>
+      <h3><dfn data-lt="id" data-dfn-type="dfn" id="id">id</dfn></h3>
+
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -248,6 +281,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#did-subject">DID Core</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
             </td>
@@ -260,22 +296,24 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
-    <section>
-      <h2><dfn data-lt="id" data-dfn-type="dfn" id="id">id</dfn></h2>
-      <p>The id of the DID Document, identifies the DID Subject.</p>
 
-      <pre class="example">
+      <pre class="example" title="Example of id property">
         {
           "id": "did:example:123",
           ...
         }
       </pre>
 
+    </section>
+
+    <section>
+      <h2><dfn data-lt="controller" data-dfn-type="dfn" id="controller">controller</dfn></h2>
+
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -283,6 +321,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#authorization-and-delegation">DID Core</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
             </td>
@@ -295,23 +336,23 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="controller" data-dfn-type="dfn" id="controller">controller</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#dfn-did-controllers">DID Controller.</a>
-
-      <pre class="example">
+      <pre class="example" title="Example of controller property">
         {
           "controller": "did:example:123",
           ...
         }
       </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="verificationMethod" data-dfn-type="dfn" id="verificationMethod">verificationMethod</dfn></h2>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -320,7 +361,10 @@ consultation with the entry maintainer.
         <tbody>
           <tr>
             <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
+              <a href="https://www.w3.org/TR/did-core/#dfn-verification-method">DID Core Terminology</a> (property definition pending)
+            </td>
+            <td>
+              JSON Schema
             </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
@@ -463,9 +507,7 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
-
-    
+    </section> 
   
     <section>
       <h2><dfn data-lt="capability" data-dfn-type="dfn" id="capability">capability</dfn></h2>
@@ -670,12 +712,6 @@ consultation with the entry maintainer.
       </table>
     </section>
 
-
-    
-    
-
-    
-
     <section>
       <h2><dfn data-lt="revoked" data-dfn-type="dfn" id="revoked">revoked</dfn></h2>
       <div class="issue">Consider removing.</div>
@@ -760,8 +796,6 @@ consultation with the entry maintainer.
         </tbody>
       </table>
     </section>
-
-   
 
     <section>
       <h2><dfn data-lt="proof" data-dfn-type="dfn" id="proof">proof</dfn></h2>
@@ -1001,10 +1035,16 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="owner" data-dfn-type="dfn" id="owner">owner</dfn></h2>
       <p>Deprecated in favor of <code>controller</code>. do not use.</p>
+
+    </section>
+
+    <section>
+      <h2><dfn data-lt="service" data-dfn-type="dfn" id="service">service</dfn> and <dfn data-lt="serviceEndpoint" data-dfn-type="dfn" id="serviceEndpoint">serviceEndpoint</dfn></h2>
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1013,7 +1053,10 @@ consultation with the entry maintainer.
         <tbody>
           <tr>
             <td>
-              JSON Schema
+              <a href="https://www.w3.org/TR/did-core/#service-endpoints">DID Core</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
             </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
@@ -1024,13 +1067,8 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="service" data-dfn-type="dfn" id="service">service</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#dfn-service">DID Service</a>
-
-      <pre class="example">
+      <pre class="example" title="Example of service and serviceEndpoint properties">
 {
   ...
   "service": [{
@@ -1041,81 +1079,16 @@ consultation with the entry maintainer.
 }
       </pre>
 
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <section>
-        <h3><dfn data-lt="serviceEndpoint" data-dfn-type="dfn" id="serviceEndpoint">serviceEndpoint</dfn></h3>
-        <a href="https://www.w3.org/TR/did-core/#dfn-service-endpoints">DID Service Endpoint</a>
-  
-        <pre class="example">
-{
-  ...
-  "serviceEndpoint": "https://edv.example.com/"
-}
-        </pre>
-  
-        <h4>Definitions</h4>
-        <table class="simple" style="width: 100%;">
-          <thead>
-            <tr>
-              <th>JSON Schema</th>
-              <th>JSON-LD</th>
-              <th>CBOR</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-              </td>
-              <td>
-                CBOR
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
     </section>
 
     <section>
       <h2><dfn data-lt="created" data-dfn-type="dfn" id="created">created</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#created">The term `created` is defined in the DID Core Specification</a>.
-
-      <pre class="example">
-{
-  "created": "2002-10-10T17:00:00Z"
-}
-      </pre>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1123,6 +1096,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#created">DID Core</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
             </td>
@@ -1135,66 +1111,61 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
+
+      <pre class="example" title="Example of created property">
+{
+  "created": "2002-10-10T17:00:00Z"
+}
+      </pre>
     </section>
 
     <section>
       <h2><dfn data-lt="updated" data-dfn-type="dfn" id="updated">updated</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#updated">The term `updated` is defined in the DID Core Specification</a>.
 
-      <pre class="example">
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#updated">DID Core</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of updated property">
 {
   "updated": "2016-10-17T02:41:00Z"
 }
       </pre>
 
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
     </section>
 
     <section>
       <h2><dfn data-lt="keyAgreement" data-dfn-type="dfn" id="keyAgreement">keyAgreement</dfn></h2>
-      <p class="issue">
-        Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>
-      </p>
-      <pre class="example">
-{
-  ...
-  "keyAgreement": [
-    {
-      "id": "did:example:123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
-      "type": "X25519KeyAgreementKey2019",
-      "controller": "did:example:123",
-      "publicKeyBase58": "9hFgmPVfmBZwRvFEyniQDBkz9LmV7gDEqytWyGZLmDXE"
-    }
-  ]
-}
-      </pre>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1202,6 +1173,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">DID Core: public-keys</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
             </td>
@@ -1214,6 +1188,53 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
+
+      <pre class="example" title="Example of keyAgreement property">
+{
+  ...
+  "keyAgreement": [
+    {
+      "id": "did:example:123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "did:example:123",
+      "publicKeyBase58": "9hFgmPVfmBZwRvFEyniQDBkz9LmV7gDEqytWyGZLmDXE"
+    }
+  ]
+}
+      </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="capabilityDelegation" data-dfn-type="dfn" id="capabilityDelegation">capabilityDelegation</dfn></h2>
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">DID Core: public-keys</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+<<<<<<< HEAD
 
       <section>
         <h2><dfn data-lt="X25519KeyAgreementKey2019" data-dfn-type="dfn" id="X25519KeyAgreementKey2019">X25519KeyAgreementKey2019</dfn></h2>
@@ -1263,13 +1284,10 @@ consultation with the entry maintainer.
       </section>
 
     </section>
+=======
+>>>>>>> a2d1735... Restructure so spec link is in tables, and table comes before example
 
-    <section>
-      <h2><dfn data-lt="capabilityDelegation" data-dfn-type="dfn" id="capabilityDelegation">capabilityDelegation</dfn></h2>
-      <p class="issue">
-        Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>
-      </p>
-      <pre class="example">
+      <pre class="example" title="Example of capabilityDelegation property">
 {
   ...
   "publicKey": [{
@@ -1294,11 +1312,16 @@ consultation with the entry maintainer.
   ]
 }
       </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="capabilityInvocation" data-dfn-type="dfn" id="capabilityInvocation">capabilityInvocation</dfn></h2>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1306,6 +1329,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">DID Core: public-keys</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
             </td>
@@ -1318,14 +1344,8 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="capabilityInvocation" data-dfn-type="dfn" id="capabilityInvocation">capabilityInvocation</dfn></h2>
-      <p class="issue">
-        Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>
-      </p>
-      <pre class="example">
+      <pre class="example" title="Example of capabilityInvocation property">
 {
   ...
   "publicKey": [{
@@ -1350,11 +1370,16 @@ consultation with the entry maintainer.
   ]
 }
       </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="authentication" data-dfn-type="dfn" id="authentication">authentication</dfn></h2>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1362,6 +1387,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#authentication">DID Core</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
             </td>
@@ -1374,14 +1402,8 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="authentication" data-dfn-type="dfn" id="authentication">authentication</dfn></h2>
-      <p class="issue">
-        Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>
-      </p>
-      <pre class="example">
+      <pre class="example" title="Example of authentication property">
 {
   ...
   "publicKey": [{
@@ -1406,11 +1428,18 @@ consultation with the entry maintainer.
   ]
 }
       </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="assertionMethod" data-dfn-type="dfn" id="assertionMethod">assertionMethod</dfn></h2>
+      
+      <p>An array of verification methods used for making assertions. Similar to <a href="#publicKey"><code>publicKey</code></a></p>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1418,6 +1447,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">DID Core: public-keys</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
             </td>
@@ -1430,16 +1462,8 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="assertionMethod" data-dfn-type="dfn" id="assertionMethod">assertionMethod</dfn></h2>
-      <p class="issue">
-        Normative definition pending. Best current link: <a href="https://www.w3.org/TR/did-core/#public-keys">public-keys</a>
-      </p>
-      <p>An array of verification methods used for making assertions. Similar to <a href='#publicKey'><code>publicKey</code></a></p>
-
-      <pre class="example">
+      <pre class="example" title="Example of assertionMethod property">
 {
   ...
   "publicKey": [{
@@ -1464,11 +1488,16 @@ consultation with the entry maintainer.
   ]
 }
       </pre>
+    </section>
+
+    <section>
+      <h2><dfn data-lt="publicKey" data-dfn-type="dfn" id="publicKey">publicKey</dfn></h2>
 
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -1476,6 +1505,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#dfn-publickey">DID Core</a>
+            </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
             </td>
@@ -1488,12 +1520,8 @@ consultation with the entry maintainer.
           </tr>
         </tbody>
       </table>
-    </section>
 
-    <section>
-      <h2><dfn data-lt="publicKey" data-dfn-type="dfn" id="publicKey">publicKey</dfn></h2>
-      <a href="https://www.w3.org/TR/did-core/#dfn-public-key-description">Public key description</a>
-      <pre class="example">
+      <pre class="example" title="Example of publicKey property">
 {
   "id": "did:example:123",
   "publicKey": [
@@ -1519,165 +1547,153 @@ consultation with the entry maintainer.
 }
       </pre>
 
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
 
       <section>
-      <h3><dfn data-lt="Ed25519VerificationKey2018" data-dfn-type="dfn" id="Ed25519VerificationKey2018">Ed25519VerificationKey2018</dfn></h3>
+        <h3><dfn data-lt="Ed25519VerificationKey2018" data-dfn-type="dfn" id="Ed25519VerificationKey2018">Ed25519VerificationKey2018</dfn></h3>
 
-      <p>A Ed25519 publicKey.</p>
+        <p>A Ed25519 publicKey. This is a <em>class</em> not a <em>property</em> - in other words, use it for the value of <code>type</code> in a <a href="#publickey">publicKey</a> object.</p>
 
+        <h4>Definitions</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON Schema</th>
+              <th>JSON-LD</th>
+              <th>CBOR</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Normative definition pending.
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/Ed25519VerificationKey2018.json">JSON Schema</a>
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+              </td>
+              <td>
+                CBOR
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <pre class="example">
-        {
-          "id": "did:example:123#ZC2jXTO6t4R501bfCXv3RxarZyUbdP2w_psLwMuY6ec",
-          "type": "Ed25519VerificationKey2018",
-          "controller": "did:example:123",
-          "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
-        }
-      </pre>
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/Ed25519VerificationKey2018.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+        <pre class="example" title="Example of Ed25519VerificationKey2018 class">
+          {
+            "id": "did:example:123#ZC2jXTO6t4R501bfCXv3RxarZyUbdP2w_psLwMuY6ec",
+            "type": "Ed25519VerificationKey2018",
+            "controller": "did:example:123",
+            "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+          }
+        </pre>
+      </section>
 
-    <section>
-      <h3><dfn data-lt="EcdsaSecp256k1VerificationKey2019" data-dfn-type="dfn" id="EcdsaSecp256k1VerificationKey2019">EcdsaSecp256k1VerificationKey2019</dfn></h3>
+      <section>
+        <h3><dfn data-lt="EcdsaSecp256k1VerificationKey2019" data-dfn-type="dfn" id="EcdsaSecp256k1VerificationKey2019">EcdsaSecp256k1VerificationKey2019</dfn></h3>
 
-      <p>A secp256k1 publicKey.</p>
+        <p>A secp256k1 publicKey. This is a <em>class</em> not a <em>property</em> - in other words, use it for the value of <code>type</code> in a <a href="#publickey">publicKey</a> object.</p>
 
+        <h4>Definitions</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON Schema</th>
+              <th>JSON-LD</th>
+              <th>CBOR</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Normative definition pending.
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/EcdsaSecp256k1VerificationKey2019.json">JSON Schema</a>
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+              </td>
+              <td>
+                CBOR
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <pre class="example">
-{
-  "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
-  "type": "EcdsaSecp256k1VerificationKey2019",
-  "controller": "did:example:123",
-  "publicKeyJwk": {
-    "crv": "secp256k1",
-    "x": "NtngWpJUr-rlNNbs0u-Aa8e16OwSJu6UiFf0Rdo1oJ4",
-    "y": "qN1jKupJlFsPFc1UkWinqljv4YE0mq_Ickwnjgasvmo",
-    "kty": "EC",
-    "kid": "WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q"
+        <pre class="example" title="Example of EcdsaSecp256k1VerificationKey2019 class">
+  {
+    "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
+    "type": "EcdsaSecp256k1VerificationKey2019",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "secp256k1",
+      "x": "NtngWpJUr-rlNNbs0u-Aa8e16OwSJu6UiFf0Rdo1oJ4",
+      "y": "qN1jKupJlFsPFc1UkWinqljv4YE0mq_Ickwnjgasvmo",
+      "kty": "EC",
+      "kid": "WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q"
+    }
   }
-}
-      </pre>
+        </pre>
+      </section>
 
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/EcdsaSecp256k1VerificationKey2019.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+      <section>
+        <h3><dfn data-lt="JwsVerificationKey2020" data-dfn-type="dfn" id="JwsVerificationKey2020">JwsVerificationKey2020</dfn></h3>
 
-    <section>
-      <h3><dfn data-lt="JwsVerificationKey2020" data-dfn-type="dfn" id="JwsVerificationKey2020">JwsVerificationKey2020</dfn></h3>
+        <p>A JWK publicKey. This is a <em>class</em> not a <em>property</em> - in other words, use it for the value of <code>type</code> in a <a href="#publickey">publicKey</a> object.</p>
 
-      <p>A JWK publicKey.</p>
-
-      <p class="issue" data-number="240">
+        <p class="issue" data-number="240">
 The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
-</p>
+        </p>
 
+        <h4>Definitions</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON Schema</th>
+              <th>JSON-LD</th>
+              <th>CBOR</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Normative definition pending.
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/JwsVerificationKey2020.json">JSON Schema</a>
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+              </td>
+              <td>
+                CBOR
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <pre class="example">
-{
-  "id": "did:example:123#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw",
-  "type": "JwsVerificationKey2020",
-  "controller": "did:example:123",
-  "publicKeyJwk": {
-    "crv": "P-256",
-    "x": "38M1FDts7Oea7urmseiugGW7tWc3mLpJh6rKe7xINZ8",
-    "y": "nDQW6XZ7b_u2Sy9slofYLlG03sOEoug3I0aAPQ0exs4",
-    "kty": "EC",
-    "kid": "_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
+        <pre class="example" title="Example of JwsVerificationKey2020 class">
+  {
+    "id": "did:example:123#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw",
+    "type": "JwsVerificationKey2020",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "P-256",
+      "x": "38M1FDts7Oea7urmseiugGW7tWc3mLpJh6rKe7xINZ8",
+      "y": "nDQW6XZ7b_u2Sy9slofYLlG03sOEoug3I0aAPQ0exs4",
+      "kty": "EC",
+      "kid": "_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
+    }
   }
-}
-      </pre>
+        </pre>
+      </section>
 
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/JwsVerificationKey2020.json">JSON Schema</a>
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
+<<<<<<< HEAD
     <section>
       <h3><dfn data-lt="RsaVerificationKey2018" data-dfn-type="dfn" id="RsaVerificationKey2018">RsaVerificationKey2018</dfn></h3>
 
@@ -1747,6 +1763,64 @@ The duplication and/or possible interaction of properties held in a JWK and a ve
 
     
 
+=======
+      <section>
+        <h3><dfn data-lt="X25519KeyAgreementKey2019" data-dfn-type="dfn" id="X25519KeyAgreementKey2019">X25519KeyAgreementKey2019</dfn></h3>
+
+        <p>A X25519 key. This is a <em>class</em> not a <em>property</em> - in other words, use it for the value of <code>type</code> in a <a href="#publickey">publicKey</a> object.</p>
+
+        <h4>Definitions</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON Schema</th>
+              <th>JSON-LD</th>
+              <th>CBOR</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                Normative definition pending.
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/X25519KeyAgreementKey2019.json">JSON Schema</a>
+              </td>
+              <td>
+                <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+              </td>
+              <td>
+                CBOR
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of X25519KeyAgreementKey2019 class using publicKeyBase58">
+  {
+    "id": "did:example:123#zC8GybikEfyNaausDA4mkT4egP7SNLx2T1d1kujLQbcP6h",
+    "type": "X25519KeyAgreementKey2019",
+    "controller": "did:example:123",
+    "publicKeyBase58": "CaSHXEvLKS6SfN9aBfkVGBpp15jSnaHazqHgLHp8KZ3Y"
+  }
+        </pre>
+
+        <pre class="example" title="Example of X25519KeyAgreementKey2019 class using publicKeyJwk">
+  {
+    "id": "did:example:123#Bob",
+    "type": "X25519KeyAgreementKey2019",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "kty":"OKP",
+      "crv":"X25519",
+      "kid":"Bob",
+      "x":"3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08"
+    }  
+  }
+        </pre>
+      </section>
+>>>>>>> a2d1735... Restructure so spec link is in tables, and table comes before example
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -379,9 +379,35 @@ consultation with the entry maintainer.
 
     <section>
       <h2><dfn data-lt="publicKeyJwk" data-dfn-type="dfn" id="publicKeyJwk">publicKeyJwk</dfn></h2>
-     
-      <a href="https://w3c-ccg.github.io/security-vocab/#publicKeyJwk">See security-vocab.</a>
-      
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#publicKeyJwk">security-vocab</a>
+            </td>
+            <td>
+              JSON Schema
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
       <pre class="example">
         {
           "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
@@ -395,41 +421,17 @@ consultation with the entry maintainer.
           }
         },
       </pre>
-
-      <h4>Definitions</h4>
-      <table class="simple" style="width: 100%;">
-        <thead>
-          <tr>
-            <th>JSON Schema</th>
-            <th>JSON-LD</th>
-            <th>CBOR</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              JSON Schema
-            </td>
-            <td>
-              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
-            </td>
-            <td>
-              CBOR
-            </td>
-          </tr>
-        </tbody>
-      </table>
     </section>
 
-    
     <section>
       <h2><dfn data-lt="allowedAction" data-dfn-type="dfn" id="allowedAction">allowedAction</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#allowedAction">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -437,6 +439,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#allowedAction">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -454,11 +459,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="expirationDate" data-dfn-type="dfn" id="expirationDate">expirationDate</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#expirationDate">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -466,6 +472,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#expirationDate">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -483,11 +492,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="delegator" data-dfn-type="dfn" id="delegator">delegator</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#delegator">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -495,6 +505,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#delegator">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -512,11 +525,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="capability" data-dfn-type="dfn" id="capability">capability</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#capability">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -524,6 +538,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#capability">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -541,11 +558,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="capabilityAction" data-dfn-type="dfn" id="capabilityAction">capabilityAction</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#capabilityAction">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -553,6 +571,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#capabilityAction">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -570,11 +591,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="capabilityChain" data-dfn-type="dfn" id="capabilityChain">capabilityChain</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#capabilityChain">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -582,6 +604,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#capabilityChain">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -599,11 +624,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="capabilityStatusList" data-dfn-type="dfn" id="capabilityStatusList">capabilityStatusList</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#capabilityStatusList">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -611,6 +637,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#capabilityStatusList">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -628,11 +657,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="canonicalizationAlgorithm" data-dfn-type="dfn" id="canonicalizationAlgorithm">canonicalizationAlgorithm</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#canonicalizationAlgorithm">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -640,6 +670,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#canonicalizationAlgorithm">See security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -657,11 +690,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="creator" data-dfn-type="dfn" id="creator">creator</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#creator">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -669,6 +703,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#creator">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -686,11 +723,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="created" data-dfn-type="dfn" id="created">created</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#created">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -698,6 +736,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#created">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -715,11 +756,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="revoked" data-dfn-type="dfn" id="revoked">revoked</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#revoked">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -727,6 +769,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#revoked">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -748,6 +793,7 @@ consultation with the entry maintainer.
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -755,6 +801,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              n/a
+            </td>
             <td>
               JSON Schema
             </td>
@@ -776,6 +825,7 @@ consultation with the entry maintainer.
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -783,6 +833,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              n/a
+            </td>
             <td>
               JSON Schema
             </td>
@@ -800,11 +853,12 @@ consultation with the entry maintainer.
     <section>
       <h2><dfn data-lt="proof" data-dfn-type="dfn" id="proof">proof</dfn></h2>
       <div class="issue">Consider removing.</div>
-      <a href="https://w3c-ccg.github.io/security-vocab/#proof">See security-vocab.</a>
+      
       <h4>Definitions</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
+            <th>Normative Definition</th>
             <th>JSON Schema</th>
             <th>JSON-LD</th>
             <th>CBOR</th>
@@ -812,6 +866,9 @@ consultation with the entry maintainer.
         </thead>
         <tbody>
           <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/security-vocab/#proof">security-vocab</a>
+            </td>
             <td>
               JSON Schema
             </td>
@@ -828,11 +885,12 @@ consultation with the entry maintainer.
       <section>
         <h3><dfn data-lt="nonce" data-dfn-type="dfn" id="nonce">nonce</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#nonce">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -840,6 +898,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#nonce">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -857,11 +918,12 @@ consultation with the entry maintainer.
       <section>
         <h3><dfn data-lt="proofPurpose" data-dfn-type="dfn" id="proofPurpose">proofPurpose</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#proofPurpose">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -869,6 +931,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#proofPurpose">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -885,12 +950,12 @@ consultation with the entry maintainer.
 
       <section>
         <h3><dfn data-lt="verificationMethod" data-dfn-type="dfn" id="verificationMethod">verificationMethod</dfn></h3>
-        <a href="https://www.w3.org/TR/did-core/#dfn-verification-method">DID Verification Method</a>
   
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -898,6 +963,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://www.w3.org/TR/did-core/#dfn-verification-method">DID Core</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -915,11 +983,12 @@ consultation with the entry maintainer.
       <section>
         <h3><dfn data-lt="jws" data-dfn-type="dfn" id="jws">jws</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#jws">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -927,6 +996,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#jws">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -941,16 +1013,15 @@ consultation with the entry maintainer.
         </table>
       </section>
 
-      
-
       <section>
         <h3><dfn data-lt="proofValue" data-dfn-type="dfn" id="proofValue">proofValue</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#proofValue">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -958,6 +1029,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#proofValue">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -972,15 +1046,15 @@ consultation with the entry maintainer.
         </table>
       </section>
  
-
       <section>
         <h3><dfn data-lt="domain" data-dfn-type="dfn" id="domain">domain</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#domain">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -988,6 +1062,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#domain">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>
@@ -1005,11 +1082,12 @@ consultation with the entry maintainer.
       <section>
         <h3><dfn data-lt="challenge" data-dfn-type="dfn" id="challenge">challenge</dfn></h3>
         <div class="issue">Consider removing.</div>
-        <a href="https://w3c-ccg.github.io/security-vocab/#challenge">See security-vocab.</a>
+        
         <h4>Definitions</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
+              <th>Normative Definition</th>
               <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
@@ -1017,6 +1095,9 @@ consultation with the entry maintainer.
           </thead>
           <tbody>
             <tr>
+              <td>
+                <a href="https://w3c-ccg.github.io/security-vocab/#challenge">security-vocab</a>
+              </td>
               <td>
                 JSON Schema
               </td>


### PR DESCRIPTION
* Puts a Normative Definition column in every definition table with a link to the appropriate section of the DID Core spec.
* Or "normative definition pending" text where we don't have a link yet.
* Moves Definitions table to immediately after the heading, with the examples following - I find this a more intuitive reading order.
* Removed descriptive text where it occurred for some properties. When the normative definitions are elsewhere and we link to it, we should *not* have descriptive text here that might be mistaken for the normative definition, in case it gets out of sync or conflicts with the normative version.
* Changed some of the links to DID Core when they linked to the terminology section, rather than the actual property definition.

I branched off `fix/updated-in-jsonld` so https://github.com/w3c/did-core-registries/pull/35 needs to be merged before this one.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core-registries/pull/44.html" title="Last updated on May 13, 2020, 3:27 PM UTC (d94b4be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core-registries/44/584d49a...d94b4be.html" title="Last updated on May 13, 2020, 3:27 PM UTC (d94b4be)">Diff</a>